### PR TITLE
feat: expose getConfigErrorMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,29 @@ export class Config {
 }
 ```
 
+## Custom validate function
+
+If the default `validate` function doesn't suite your use case, you can provide it like in the example below:
+
+```ts
+TypedConfigModule.forRoot({
+    schema: RootConfig,
+    validate: (rawConfig: any) => {
+        const config = plainToClass(RootConfig, rawConfig)
+        const schemaErrors = validateSync(config, {
+            forbidUnknownValues: true,
+            whitelist: true,
+        })
+
+        if (schemaErrors.length) {
+            throw new Error(TypedConfigModule.getConfigErrorMessage(schemaErrors))
+        }
+
+        return config as RootConfig
+  },
+})
+```
+
 ## Using config outside Nest's IoC container (Usage in decorators)
 
 ### Caution!

--- a/lib/typed-config.module.ts
+++ b/lib/typed-config.module.ts
@@ -137,7 +137,7 @@ export class TypedConfigModule {
     return config;
   }
 
-  private static getConfigErrorMessage(errors: ValidationError[]) {
+  static getConfigErrorMessage(errors: ValidationError[]): string {
     const messages = this.formatValidationError(errors)
       .map(({ property, value, constraints }) => {
         const constraintMessage = Object.entries(


### PR DESCRIPTION
Hey @Nikaple, thanks a lot for this awesome lib!

In our use case, we wanted to override the `validate` function and wanted to reuse `getConfigErrorMessage` inside it. This PRs makes it public so that it can be reused.
I also added an example of how to pass a custom`validate` option.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`getConfigErrorMessage` function is private.

Issue Number: N/A


## What is the new behavior?

`getConfigErrorMessage` function is now public.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information