### PR TITLE
feat: dotenv loader will assign env variables to process.env

### DIFF
--- a/lib/loader/dotenv-loader.ts
+++ b/lib/loader/dotenv-loader.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import { resolve } from 'path';
 import set from 'lodash.set';
 import { loadPackage } from '../utils/load-package.util';
+import { debug } from '../utils/debug.util';
 
 export interface DotenvLoaderOptions {
   /**
@@ -71,7 +72,7 @@ const loadEnvFile = (options: DotenvLoaderOptions): Record<string, any> => {
     ? options.envFilePath
     : [options.envFilePath || resolve(process.cwd(), '.env')];
 
-  let config: ReturnType<typeof dotenv.parse> = {};
+  let config: Record<string, string> = {};
   for (const envFilePath of envFilePaths) {
     if (fs.existsSync(envFilePath)) {
       config = Object.assign(
@@ -86,6 +87,16 @@ const loadEnvFile = (options: DotenvLoaderOptions): Record<string, any> => {
         config = dotenvExpand({ parsed: config }).parsed!;
       }
     }
+
+    Object.entries(config).forEach(([key, value]) => {
+      if (!Object.prototype.hasOwnProperty.call(process.env, key)) {
+        process.env[key] = value;
+      } else {
+        debug(
+          `"${key}" is already defined in \`process.env\` and will not be overwritten`,
+        );
+      }
+    });
   }
   return config;
 };


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #13 


## What is the new behavior?

Variables from .env will be assigned to `process.env` automatically, and will not override the variables that exists on `process.env`

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information