### PR TITLE
feat: support selecting optional configs with selectConfig

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -31,8 +31,8 @@ Issue Number: N/A
 
 ## Does this PR introduce a breaking change?
 
-[ ] Yes
-[ ] No
+- [ ] Yes
+- [ ] No
 
 <!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x]
     steps:
       - uses: actions/checkout@v2
 

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ export class Config {
 }
 ```
 
-## Type casting on environment variables
+## Transforming the raw configuration
 
 Environment variables are always loaded as strings, but configuration schemas are not. In such case, you can transform the raw config with `normalize` function:
 

--- a/README.md
+++ b/README.md
@@ -650,6 +650,8 @@ export const routeConfig = selectConfig(ConfigModule, RouteConfig);
 
 That's it! You can use `rootConfig` and `routeConfig` anywhere in your app now!
 
+> If target configuration model is marked with `@Optional()`, you should call `selectConfig` with `{ allowOptional: true }` to allow optional configuration.
+
 ```ts
 // app.controller.ts
 import { Controller, Get } from '@nestjs/common';

--- a/lib/utils/select-config.util.ts
+++ b/lib/utils/select-config.util.ts
@@ -1,16 +1,31 @@
 import { DynamicModule, ValueProvider } from '@nestjs/common';
 import { ClassConstructor } from 'class-transformer';
 
-export const selectConfig = <T>(
+export interface SelectConfigOptions {
+  /**
+   * when true, allow undefined config declared with `@IsOptional()`
+   */
+  allowOptional?: boolean;
+}
+
+export const selectConfig = <T, Option extends SelectConfigOptions>(
   module: DynamicModule,
   Config: ClassConstructor<T>,
-): T => {
+  options?: Option,
+): Option extends { allowOptional: true } ? T | undefined : T => {
   const providers = module.providers as ValueProvider<T>[];
   const selectedConfig = (providers || []).filter(
     ({ provide }) => provide === Config,
   )[0];
+  if (options?.allowOptional) {
+    return selectedConfig?.useValue;
+  }
   if (!selectedConfig) {
-    throw new Error(`You can only select config which exists in providers`);
+    throw new Error(
+      'You can only select config which exists in providers. \
+      If the config being selected is marked as optional, \
+      please pass `allowOptional` in options argument.',
+    );
   }
   return selectedConfig.useValue;
 };

--- a/tests/e2e/select-config.spec.ts
+++ b/tests/e2e/select-config.spec.ts
@@ -16,7 +16,7 @@ describe('Local toml', () => {
     expect(tableConfig.name).toBe('test');
   });
 
-  it(`can only select existing config`, async () => {
+  it(`can only select existing config without 'allowOptional'`, async () => {
     const module = AppModule.withRawModule();
 
     expect(() => selectConfig(module, class {})).toThrowError(
@@ -25,5 +25,19 @@ describe('Local toml', () => {
     expect(() => selectConfig({ module: class {} }, class {})).toThrowError(
       'You can only select config which exists in providers',
     );
+  });
+
+  it(`can select optional config with 'allowOptional'`, async () => {
+    const module = AppModule.withRawModule();
+
+    expect(
+      selectConfig(module, class {}, { allowOptional: true }),
+    ).toBeUndefined();
+    expect(
+      selectConfig({ module: class {} }, class {}, { allowOptional: true }),
+    ).toBeUndefined();
+
+    const config = selectConfig(module, Config, { allowOptional: true });
+    expect(config?.isAuthEnabled).toBe(true);
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Selecting optional config marked as `@Optional()` will throw error when config does not exist.

Issue Number: N/A

## What is the new behavior?

Can provide an optional argument `{ allowOptional: true }` to select optional config.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
