### PR TITLE
fix: add an option to allow empty env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,11 @@ export interface DirectoryLoaderOptions extends OptionsSync {
    * Default: true
    */
   ignoreEnvironmentVariableSubstitution?: boolean;
+  /**
+   * If "true", disallow undefined environment variables.
+   * Default: true
+   */
+  disallowUndefinedEnvironmentVariables?: boolean;
 }
 ```
 

--- a/lib/loader/file-loader.ts
+++ b/lib/loader/file-loader.ts
@@ -41,6 +41,11 @@ export interface FileLoaderOptions extends Partial<OptionsSync> {
    * Default: true
    */
   ignoreEnvironmentVariableSubstitution?: boolean;
+  /**
+   * If "true", disallow undefined environment variables.
+   * Default: true
+   */
+  disallowUndefinedEnvironmentVariables?: boolean;
 }
 
 const getSearchOptions = (options: FileLoaderOptions) => {
@@ -79,6 +84,7 @@ const getSearchOptions = (options: FileLoaderOptions) => {
 const placeholderResolver = (
   template: string,
   data: Record<string, any>,
+  disallowUndefinedEnvironmentVariables: boolean,
 ): string => {
   const replace = (placeholder: any, key: string) => {
     let value = data;
@@ -86,7 +92,7 @@ const placeholderResolver = (
       value = value[property];
     }
 
-    if (!value) {
+    if (!value && disallowUndefinedEnvironmentVariables) {
       throw new Error(
         `Environment variable is not set for variable name: '${key}'`,
       );
@@ -147,6 +153,7 @@ export const fileLoader = (
       const replacedConfig = placeholderResolver(
         JSON.stringify(result.config),
         process.env,
+        options.disallowUndefinedEnvironmentVariables ?? true,
       );
       config = JSON.parse(replacedConfig);
     }

--- a/tests/e2e/environment-substitute-failed.spec.ts
+++ b/tests/e2e/environment-substitute-failed.spec.ts
@@ -1,9 +1,22 @@
 import { AppModule } from '../src/app.module';
 
 describe('Environment variable substitutions failure', () => {
-  it(`should load .env.yaml and should not throw error`, async () => {
-    expect(() => AppModule.withYamlSubstitution(false)).toThrowError(
+  it(`should load .env.yaml and should throw error`, async () => {
+    expect(() =>
+      AppModule.withYamlSubstitution({
+        ignoreEnvironmentVariableSubstitution: false,
+      }),
+    ).toThrowError(
       `Environment variable is not set for variable name: 'TABLE_NAME'`,
     );
+  });
+
+  it(`should load .env.yaml and should not throw error when disallowUndefinedEnvironmentVariables is set to false`, async () => {
+    expect(() =>
+      AppModule.withYamlSubstitution({
+        ignoreEnvironmentVariableSubstitution: false,
+        disallowUndefinedEnvironmentVariables: false,
+      }),
+    ).not.toThrow();
   });
 });

--- a/tests/e2e/environment-substitute.spec.ts
+++ b/tests/e2e/environment-substitute.spec.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
+import { FileLoaderOptions } from '../../lib';
 import { AppModule } from '../src/app.module';
 import { DatabaseConfig } from '../src/config.model';
 
@@ -8,10 +9,10 @@ describe('Environment variable substitutions', () => {
 
   const tableName = 'users';
 
-  const init = async (ignoreSubstitution: boolean) => {
+  const init = async (options: FileLoaderOptions) => {
     process.env['TABLE_NAME'] = tableName;
     const module = await Test.createTestingModule({
-      imports: [AppModule.withYamlSubstitution(ignoreSubstitution)],
+      imports: [AppModule.withYamlSubstitution(options)],
     }).compile();
 
     app = module.createNestApplication();
@@ -19,13 +20,13 @@ describe('Environment variable substitutions', () => {
   };
 
   it(`should load .env.yaml and substitute environment variable`, async () => {
-    await init(false);
+    await init({ ignoreEnvironmentVariableSubstitution: false });
     const databaseConfig = app.get(DatabaseConfig);
     expect(databaseConfig.table.name).toBe(tableName);
   });
 
   it(`should load .env.yaml and substitute environment variable`, async () => {
-    await init(true);
+    await init({ ignoreEnvironmentVariableSubstitution: true });
     const databaseConfig = app.get(DatabaseConfig);
     expect(databaseConfig.table.name).toBe('${TABLE_NAME}');
   });

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { parse as parseYaml } from 'yaml';
 import {
   directoryLoader,
+  FileLoaderOptions,
   remoteLoader,
   RemoteLoaderOptions,
   TypedConfigModule,
@@ -223,7 +224,7 @@ export class AppModule {
     };
   }
 
-  static withYamlSubstitution(ignoreSubstitution: boolean): DynamicModule {
+  static withYamlSubstitution(options: FileLoaderOptions): DynamicModule {
     return {
       module: AppModule,
       imports: [
@@ -231,7 +232,7 @@ export class AppModule {
           schema: Config,
           load: fileLoader({
             absolutePath: join(__dirname, '.env.sub.yaml'),
-            ignoreEnvironmentVariableSubstitution: ignoreSubstitution,
+            ...options,
           }),
         }),
       ],


### PR DESCRIPTION
closes #195

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #195

## What is the new behavior?

An option `disallowUndefinedEnvironmentVariables` is added, defaults to true to ensure backwards compatibility

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
