### PR TITLE
Doc: FileLoaderOptions flag should be mentioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,14 @@ And you have set environment variable for port
 PORT=9000
 ```
 
+And set ignoreEnvironmentVariableSubstitution to false in the FileLoaderOptions
+
+```
+load: fileLoader({
+  ignoreEnvironmentVariableSubstitution: false,
+}),
+```
+
 then `fileloader` will resolve `${PORT}` placeholder and replace with environment variable.
 And you will get new config like below one
 


### PR DESCRIPTION
FileLoaderOptions.ignoreEnvironmentVariableSubstitution defaults to true which means it must be explicitly set.

Would make sense to call that out in the docs to avoid confusion, thinking the environment variable substitutions don't work

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
