### PR TITLE
feat(dotenv-loader): add key transformer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,19 @@ export interface DotenvLoaderOptions {
   separator?: string;
 
   /**
+   * If set, this function will transform all environment variable keys prior to parsing.
+   *
+   * Be aware: If you transform multiple keys to the same value only one will remain!
+   *
+   * @example
+   *
+   * .env file: `PORT=8080` and `keyTransformer: key => key.toLowerCase()` results in `{"port": 8080}`
+   *
+   * @param key environment variable key
+   */
+  keyTransformer?: (key: string) => string;
+
+  /**
    * If "true", environment files (`.env`) will be ignored.
    */
   ignoreEnvFile?: boolean;

--- a/tests/e2e/dotenv.spec.ts
+++ b/tests/e2e/dotenv.spec.ts
@@ -154,6 +154,35 @@ describe('Dotenv loader', () => {
     expect(tableConfig.name).toBe('expand');
   });
 
+  it(`should be able to load config from transformed environment variables keys`, async () => {
+    process.env = {
+      isAuthEnabled: 'true',
+      DATABASE__HOST: 'should-be-used',
+      DATABASE__PORT: '4000',
+      DATABASE__TABLE__NAME: 'should-be-used',
+    };
+
+    const module = await Test.createTestingModule({
+      imports: [
+        AppModule.withDotenv({
+          separator: '__',
+          keyTransformer: key =>
+            key.replace(/[A-Z0-9]{2,}/g, match => match.toLowerCase()),
+          ignoreEnvFile: true,
+        }),
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    await app.init();
+
+    const config = app.get(Config);
+    expect(config.isAuthEnabled).toBe(true);
+    expect(config.database.host).toBe('should-be-used');
+    expect(config.database.port).toBe(4000);
+    expect(config.database.table.name).toBe('should-be-used');
+  });
+
   afterEach(async () => {
     await app?.close();
   });


### PR DESCRIPTION
Add option to transform environment variable keys before parsing them. This allows changes to be made prior to parsing which makes having to use complex normalize functions obsolete.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently environment variables that are loaded using the `dotenv-loader` cannot be reformatted. These variables are by convention capitalized which results in a config that looks like this:
`.env`file:
```.env
DATABASE__HOST=localhost
DATABASE__PORT=4000
```
`config`:
```ts
config: {
    DATABASE: {
        HOST: 'localhost',
        PORT: 4000,
    },
}
```

(The config can be changed after the `dotenv-loader` by using the `normalize`function of the `TypedConfigModule`, more about this [below](#other-information).)

Issue Number: N/A

## What is the new behavior?

The new behavior allows users to pass a function to the new `keyTransformer` option. This function can modify the environment variable keys in any way the user wants. The function should take one argument and return a string. 
An example with a simple function that uses `toLowerCase()`:
`.env`file:
```.env
DATABASE__HOST=localhost
DATABASE__PORT=4000
```
```ts
TypedConfigModule.forRoot({
    schema: Config,
    load: dotenvLoader({
        separator: '__',
        ignoreEnvFile: false,
        keyTransformer: key => key.toLowerCase()
    }),
}),
```
`config`:
```ts
config: {
    database: {
        host: 'localhost',
        port: 4000,
    },
}
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
I know that the simple example with `toLowerCase()` can easily be achieved by using the `normalize` function of the `TypedConfigModule`, however this can become quite difficult (traversing the object recursively) and long. To obtain the same result the following configuration can be used:
```ts
TypedConfigModule.forRoot({
    schema: Config,
    load: dotenvLoader({
        separator: '__',
        ignoreEnvFile: false,
    }),
    normalize: function transform(config) {
        return Object.entries(config)
            .reduce<Record<string, any>>((acc, [key, value]) => {
                if (Object.getPrototypeOf(value) === Object.prototype) {
                    acc[key.toLowerCase()] = transform(value);
                } else {
                    acc[key.toLowerCase()] = value;
                }
                return acc;
            }, {});
    },
}),
```
Like I mentioned earlier, this can become quite complex.

An added benefit of this change is the option to use `dotenv-loader`separately and still be able to reformat the keys. This allows the user to use the same classes and validation without requiring the app to be started (e.g. when using the CLI).