### PR TITLE
fix: do not attempt substitution if the loader failed

### DIFF
--- a/lib/loader/file-loader.ts
+++ b/lib/loader/file-loader.ts
@@ -100,8 +100,11 @@ export const fileLoader = (
       searchPlaces,
       ...options,
       loaders,
-      transform: (result: Record<string, any>) => {
-        if (options.ignoreEnvironmentVariableSubstitution ?? true) {
+      transform: (result: Record<string, any> | null) => {
+        if (
+          !result ||
+          (options.ignoreEnvironmentVariableSubstitution ?? true)
+        ) {
           return result;
         }
 

--- a/tests/e2e/yaml-file-substitutions.spec.ts
+++ b/tests/e2e/yaml-file-substitutions.spec.ts
@@ -225,6 +225,18 @@ describe('Environment variable substitutions error cases', () => {
     );
   });
 
+  it('should not attempt substitution if the loader failed', async () => {
+    expect(() =>
+      AppModule.withYamlSubstitution(
+        {
+          ignoreEnvironmentVariableSubstitution: true,
+        },
+        ConfigWithAlias,
+        ['.env-missing.yaml'],
+      ),
+    ).toThrowError(`Failed to find configuration file.`);
+  });
+
   it('array primitives substitution', async () => {
     expect(() =>
       AppModule.withYamlSubstitution(

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -49,7 +49,8 @@ export type TestYamlFile =
   | '.env-reference-object.sub.yaml'
   | '.env-reference-array-of-primitives.sub.yaml'
   | '.env-advanced-backward-reference.sub.yaml'
-  | '.env-with-default.sub.yaml';
+  | '.env-with-default.sub.yaml'
+  | '.env-missing.yaml';
 
 @Module({})
 export class AppModule {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When substitution of environment variables in enabled in the `fileLoader`, an exception is generated as the check for whether or not the config actually loaded is missing:

```
TypeError: Cannot read properties of null (reading 'config')                                                                                                                                              
    at Object.transform (/home/jacquesg/dev/projects/asterias/deianira/node_modules/nest-typed-config/lib/loader/file-loader.ts:120:41)
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The validity is checked, and the correct error is now generated:

```
/home/jacquesg/dev/projects/asterias/deianira/node_modules/nest-typed-config/lib/typed-config.module.ts:79
    return load();
           ^
Error: Failed to find configuration file.
    at /home/jacquesg/dev/projects/asterias/deianira/node_modules/nest-typed-config/lib/loader/file-loader.ts:135:5
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
