### PR TITLE
fix: allow reflect-metadata versions in the 0.2 series

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "peerDependencies": {
     "@nestjs/common": ">= 6.10.0 < 11",
-    "reflect-metadata": "^0.1.12",
+    "reflect-metadata": ">= 0.1.12 < 0.3",
     "rxjs": ">= 6.0.0 < 8"
   },
   "commitlint": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/Nikaple/nest-typed-config/blob/main/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Related issue linked using `fixes #number`
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The version of `reflect-metadata` is pinned to `0.1.12`.

Issue Number: N/A

## What is the new behavior?

`reflect-metadata` versions less than `0.3` is now accepted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

NestJS has moved on to the `0.2` series: https://github.com/nestjs/nest/blob/7f00840c074ba5a5f233f73ef6c8456115abd7c1/package.json#L73
